### PR TITLE
update to v1.3.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,13 +11,11 @@
   <!-- jQuery-->
   <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js"></script>
 
-  <!-- Leaflet (CSS and JS) -->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
-  integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
-  crossorigin=""/>
-  <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"
-  integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA=="
-  crossorigin=""></script>
+  <!-- Load Leaflet CSS and JS-->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 
   <!-- PapaParse -->
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.0/papaparse.min.js"></script>
@@ -27,7 +25,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.1/js/fontawesome.min.js"></script>
 
   <!-- leaflet-providers-->
-  <script src="https://unpkg.com/leaflet-providers@1.10.2/leaflet-providers.js"></script>
+  <script src="https://unpkg.com/leaflet-providers@2.0.0/leaflet-providers.js"></script>
 
   <!-- Leaflet.awesome-markers v2.0.4, manually updated to svg to allow hex and material icons -->
   <link rel="stylesheet" type="text/css" href="scripts/Leaflet.awesome-markers/dist/leaflet.awesome-markers.css">

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -17,6 +17,7 @@ var constants = {
 	_googleAnalytics: 'Google Analytics Tracking ID',
 	// Map Settings
 	_tileProvider: 'Basemap Tiles',
+  _tileProviderApiKey: 'Basemap Tiles API Key',
 	_markercluster: 'Cluster Markers',
   _introPopupText: 'Intro Popup Text',
   _initZoom: 'Initial Zoom',

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -926,13 +926,23 @@ $(window).on('load', function() {
    * Loads the basemap and adds it to the map
    */
   function addBaseMap() {
+
     var basemap = trySetting('_tileProvider', 'CartoDB.Positron');
+    
     L.tileLayer.provider(basemap, {
-      maxZoom: 18
+      maxZoom: 18,
+
+      // Pass the api key to most commonly used parameters
+      apiKey: trySetting('_tileProviderApiKey', ''),
+      apikey: trySetting('_tileProviderApiKey', ''),
+      key: trySetting('_tileProviderApiKey', ''),
+      accessToken: trySetting('_tileProviderApiKey', '')
     }).addTo(map);
+
     L.control.attribution({
       position: trySetting('_mapAttribution', 'bottomright')
     }).addTo(map);
+
   }
 
   /**


### PR DESCRIPTION
In response to your email, I recommend that you accept this pull request to update your code to v1.3.0.
Next, go to [our Google Sheet Template v1.3.0](https://docs.google.com/spreadsheets/d/1ZxvU8eGyuN9M8GxTU9acKVJv70iC3px_m3EVFsOHN9g/edit#gid=0) > Options tab and copy row 12, then paste in [your Google Sheet](https://docs.google.com/spreadsheets/d/1p-ZMBCxy-OyHzjpIalIIl0geAonQKip_kuKtnZcpoTM/edit#gid=0). See attached screenshot of new map tile options.
Finally, create a new row 13 in your Google Sheet, and copy and paste the contents of our row 13, in case you choose a new map type that requires an API key (and follow instructions in column C if needed).
![Screenshot 2023-10-30 at 7 55 08 PM](https://github.com/gbventura/Hispanic_periodicals/assets/649719/b0a971d1-0375-4c4b-8cfe-5a1cd3d9c3c7)

